### PR TITLE
1.12.2 Mappings are broken

### DIFF
--- a/1_12/build.gradle
+++ b/1_12/build.gradle
@@ -51,7 +51,7 @@ unimined.minecraft {
 
     mappings {
         searge()
-        mcp("stable", "12-1.7.10")
+        mcp("stable", "39-1.12")
     }
 
     defaultRemapJar = false


### PR DESCRIPTION
```
> Task :compileJava FAILED
                if (!theWorld.getChunkFromChunkCoords(((int) thePlayer.posX) >> 4, ((int) thePlayer.posZ) >> 4).isEmpty()) {
                             ^
  symbol:   method getChunkFromChunkCoords(int,int)
  location: variable theWorld of type net.minecraft.client.multiplayer.WorldClient
1 error
```