### PR TITLE
fix(fabric-api): download runtime JAR from GitHub Releases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,10 +128,12 @@ runs:
 
     - if: inputs.fabric-api != 'none'
       name: Download fabric-api v${{ inputs.fabric-api }}
-      run: >
-        curl --create-dirs -o run/mods/fabric-api-${{ inputs.fabric-api }}+${{ inputs.mc }}.jar
-        https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/${{ inputs.fabric-api }}+${{ inputs.mc }}/fabric-api-${{ inputs.fabric-api }}+${{ inputs.mc }}.jar
-      shell: bash
+      uses: robinraju/release-downloader@a96f54c1b5f5e09e47d9504526e96febd949d4c2 # v1.11
+      with:
+        repository: FabricMC/fabric-api
+        tag: '${{ inputs.fabric-api }}+${{ inputs.mc }}'
+        fileName: 'fabric-api-${{ inputs.fabric-api }}+${{ inputs.mc }}.jar'
+        out-file-path: run/mods
 
     - if: inputs.fabric-gametest-api != 'none'
       name: Download fabric-gametest-api v${{ inputs.fabric-gametest-api }}


### PR DESCRIPTION
The `fabric-api` input downloaded the top-level JAR from Fabric's Maven repo. For some older releases that JAR is a thin aggregator with no bundled submodules, so mods depending on Fabric API submodules crash at runtime (e.g. `NoClassDefFoundError` for `fabric-networking-api-v1`).

Example: Maven `0.77.0+1.18.2` is 4,877 bytes with 0 nested modules, while the GitHub Release JAR is 1.47 MB with 45. Fabric fixed this in the 1.19.2 branch but never backported it, so it only breaks on older versions.

This switches the download to `robinraju/release-downloader`, pulling `fabric-api-<version>+<mc>.jar` from FabricMC/fabric-api releases. The release asset is the full distribution for both old and new versions.

Note: the source moves from Fabric's Maven CDN to the GitHub release API. `release-downloader` uses `GITHUB_TOKEN`, so rate limits shouldn't bite in normal CI.

Closes #141